### PR TITLE
Add features to the python script from BQ ML package

### DIFF
--- a/carto_extension.py
+++ b/carto_extension.py
@@ -524,6 +524,10 @@ def test(component):
         for test_id, outputs in results[component["name"]].items():
             test_folder = os.path.join(component_folder, "test", "fixtures")
             test_filename = os.path.join(test_folder, f"{test_id}.json")
+            if str(test_id).startswith("skip_"):
+                # Don't compare results, it will only throw an error
+                # if there is an issue when running on BigQuery
+                continue
             with open(test_filename, "r") as f:
                 expected = json.load(f)
                 for output_name, output in outputs.items():

--- a/carto_extension.py
+++ b/carto_extension.py
@@ -11,6 +11,7 @@ import os
 import re
 import snowflake.connector
 import zipfile
+import io
 
 WORKFLOWS_TEMP_SCHEMA = "WORKFLOWS_TEMP"
 EXTENSIONS_TABLENAME = "WORKFLOWS_EXTENSIONS"

--- a/carto_extension.py
+++ b/carto_extension.py
@@ -175,7 +175,7 @@ def create_sql_code_bq(metadata):
         DECLARE proceduresArray ARRAY<STRING>;
         DECLARE i INT64 DEFAULT 0;
 
-        CREATE OR REPLACE TABLE {WORKFLOWS_TEMP_PLACEHOLDER}.{EXTENSIONS_TABLENAME} (
+        CREATE IF NOT EXISTS TABLE {WORKFLOWS_TEMP_PLACEHOLDER}.{EXTENSIONS_TABLENAME} (
             name STRING,
             metadata STRING,
             procedures STRING

--- a/carto_extension.py
+++ b/carto_extension.py
@@ -174,7 +174,7 @@ def create_sql_code_bq(metadata):
         DECLARE proceduresArray ARRAY<STRING>;
         DECLARE i INT64 DEFAULT 0;
 
-        CREATE TABLE IF NOT EXISTS {WORKFLOWS_TEMP_PLACEHOLDER}.{EXTENSIONS_TABLENAME} (
+        CREATE OR REPLACE TABLE {WORKFLOWS_TEMP_PLACEHOLDER}.{EXTENSIONS_TABLENAME} (
             name STRING,
             metadata STRING,
             procedures STRING

--- a/carto_extension.py
+++ b/carto_extension.py
@@ -593,7 +593,7 @@ def capture(component):
             os.makedirs(test_folder, exist_ok=True)
             test_filename = os.path.join(test_folder, f"{test_id}.json")
             with open(test_filename, "w") as f:
-                f.write(json.dumps(outputs, indent=2))
+                f.write(json.dumps(outputs, indent=2, default=str))
     print("Fixtures correctly captured.")
 
 

--- a/carto_extension.py
+++ b/carto_extension.py
@@ -439,6 +439,13 @@ def _get_test_results(metadata, component):
         components = metadata["components"]
     current_folder = os.path.dirname(os.path.abspath(__file__))
     components_folder = os.path.join(current_folder, "components")
+
+    project = os.getenv("BQ_TEST_PROJECT")
+    assert project, "BQ_TEST_PROJECT environment variable is not set"
+
+    dataset = os.getenv("BQ_TEST_DATASET")
+    assert dataset, "BQ_TEST_DATASET environment variable is not set"
+
     for component in components:
         component_folder = os.path.join(components_folder, component["name"])
         test_folder = os.path.join(component_folder, "test")
@@ -449,7 +456,12 @@ def _get_test_results(metadata, component):
         # run tests
         test_configuration_file = os.path.join(test_folder, "test.json")
         with open(test_configuration_file, "r") as f:
-            test_configurations = json.load(f)
+            test_configurations = json.loads(
+                f.read()
+                .replace("${BQ_TEST_PROJECT}", project)
+                .replace("${BQ_TEST_DATASET}", dataset)
+            )
+
         tables = {}
         component_results = {}
         for test_configuration in test_configurations:


### PR DESCRIPTION
This PR includes some changes that were written from the [BigQuery ML extension package](https://github.com/CartoDB/workflows-extension-ml-bq) back to the upstream, which includes:
1. **BigQuery project and dataset substitution within test fixtures and expected values**. We needed it to check `model_fqn` within tables, for instance. For captured results, the process is still manual, although we could try to implement it automatically.
2. **Safer JSON dumping**, using `default=str` to serialize some stubborn data types.
3. **Decimal numbers truncation (to three decimal places)**, which was needed to test the ML models and can be useful to test some other non-deterministic or non-stable methods.
4. **Test expectancy skipping**, by prefixing the test ID with `skip_` the test will only check for success in the BigQuery side, not check against any kind of expected result.

These changes are very ad-hoc and will probably cause issues in the general template, so we can use this PR to check which ones are interesting, if there is a better way to do any of them, or how to polish them.