### PR TITLE
Include changes from the Snowflake ML extension package

### DIFF
--- a/carto_extension.py
+++ b/carto_extension.py
@@ -708,7 +708,11 @@ def dataframe_to_dict(df: pd.DataFrame) -> dict[str, Any]:
     """
     for column, dtype in df.dtypes.to_dict().items():
         if dtype == 'object':
-            value = df.iloc[0].loc[column]
+            try:
+                value = df.iloc[0].loc[column]
+            except IndexError:
+                break
+
             if isinstance(value, np.ndarray):
                 # Convert from numpy to primitive types
                 df[column] = df[column].apply(lambda arr: arr.tolist())

--- a/carto_extension.py
+++ b/carto_extension.py
@@ -747,7 +747,9 @@ def normalize_json(original, decimal_places=3):
 
 def normalize_element(value, decimal_places=3):
     """Format a single scalar value in the desired format."""
-    if isinstance(value, float) and math.isnan(value):
+    if isinstance(value, dict) or isinstance(value, list):
+        return sorted(map(normalize_element, value))
+    elif isinstance(value, float) and math.isnan(value):
         return "nan"
     elif isinstance(value, float):
         return round(value, decimal_places)

--- a/carto_extension.py
+++ b/carto_extension.py
@@ -100,6 +100,7 @@ def create_metadata():
         fullrun_file = os.path.join(components_folder, component, "src", "fullrun.sql")
         with open(fullrun_file, "r") as f:
             fullrun_code = f.read()
+
         code_hash = (
             int(hashlib.sha256(fullrun_code.encode("utf-8")).hexdigest(), 16) % 10**8
         )
@@ -267,6 +268,7 @@ def get_procedure_code_sf(component):
                 BEGIN
                     -- TODO: remove once the database is set for dry-runs
                     EXECUTE IMMEDIATE \\'USE DATABASE \\' || SPLIT_PART(_workflows_temp, \\'.\\', 0);
+
                 {dryrun_code}
                 END;
             ELSE
@@ -438,6 +440,7 @@ def infer_schema_field_bq(key: str, value: Any) -> bigquery.SchemaField:
         raise NotImplementedError(
             f"Could not infer a BigQuery SchemaField for {value} ({type(value)})"
         )
+
 def _upload_test_table_bq(filename, component):
     schema = []
     with open(filename) as f:
@@ -784,6 +787,7 @@ def capture(component):
                 contents = json.dumps(outputs, indent=2, default=str)
                 contents = substitute_keys(contents, dotenv=dotenv)
                 f.write(contents)
+
     print("Fixtures correctly captured.")
 
 

--- a/carto_extension.py
+++ b/carto_extension.py
@@ -46,6 +46,8 @@ def sf_client():
                 user=os.getenv("SF_USER"),
                 password=os.getenv("SF_PASSWORD"),
                 account=os.getenv("SF_ACCOUNT"),
+                database=os.getenv("SF_TEST_DATABASE"),
+                schema=os.getenv("SF_TEST_SCHEMA"),
             )
         except Exception as e:
             raise Exception(f"Error connecting to SnowFlake: {e}")

--- a/carto_extension.py
+++ b/carto_extension.py
@@ -370,20 +370,20 @@ def deploy(destination):
         deploy_sf(metadata, destination)
 
 
-def substitute_vars(text) -> str:
+def substitute_vars(text: str) -> str:
     """Substitute all variables in a string with their values from the environment.
 
-    For a given string, all the variables using the syntax `${variable_name}`
+    For a given string, all the variables using the syntax `%%{variable_name}%%`
     will be interpolated with their values from the corresponding env vars. It will
     raise a ValueError if any variable name is not present in the environment.
     """
-    pattern = r"\${([a-zA-Z0-9_]+)}"
+    pattern = r"%%\{([a-zA-Z0-9_]+)\}%%"
 
     for variable in re.findall(pattern, text, re.MULTILINE):
         env_var_value = os.getenv(variable)
         if env_var_value is None:
             raise ValueError(f"Environment variable {variable} is not set")
-        text = text.replace(f"${{{variable}}}", env_var_value)
+        text = text.replace(f"%%{{{variable}}}%%", env_var_value)
 
     return text
 
@@ -693,6 +693,7 @@ def capture(component):
             test_filename = os.path.join(test_folder, f"{test_id}.json")
             with open(test_filename, "w") as f:
                 f.write(json.dumps(outputs, indent=2, default=str))
+
     print("Fixtures correctly captured.")
 
 

--- a/carto_extension.py
+++ b/carto_extension.py
@@ -696,25 +696,13 @@ def test(component):
 
     print("Extension correctly tested.")
 
-def _simplify_types(type_name: str) -> str:
-    """Return a simple version of the type to perform checks.
-    
-    This function ignores the precision of numeric types, which is of no relevance."""
-    # TODO: find a way to get the correct numeric type or fetch from the cloud
-    if type_name.startswith("int"):
-        return "number"
-    elif type_name.startswith("float"):
-        return "number"
-    else:
-        return type_name
 
 def check_schema(dry_result, full_result) -> bool:
-    dry_schema = dry_result.dtypes.astype(str).apply(_simplify_types).to_dict()
-    full_schema = full_result.dtypes.astype(str).apply(_simplify_types).to_dict()
-
-    # TODO: only comparing column names since types are not being properly fetched
-    # return dry_schema == full_schema
+    """Compare two different DataFrames two have the same columns."""
+    dry_schema = dry_result.dtypes.astype(str).to_dict()
+    full_schema = full_result.dtypes.astype(str).to_dict()
     return dry_schema.keys() == full_schema.keys()
+
 
 def normalize_json(original, decimal_places=3):
     """Ensure that the input for a test is in an uniform format.

--- a/doc/procedure.md
+++ b/doc/procedure.md
@@ -49,7 +49,10 @@ Do not generate tables with names others than the ones provided in the variables
 
 ## Replacing placeholders with environment variables
 
-You can use placeholders in your code as `${var_name}`. Then you can define the environment variable `var_name` in your system variables or in an `.env` file in the repository folder, and the placeholder will be replaced when packaging or deploying the application.
+You can use placeholders in your code as `@@variable_name@@`. Then you can define the environment variable `var_name` (or `VAR_NAME`) in your system variables or in an `.env` file in the repository folder, and the placeholder will be replaced when testing or deploying the application. This will work in the code, test configurations and test fixtures. This substitution is **not** performed when packaging the application - in that case it is delegated to CARTO on installation (for example, to substitute `@@analytics_toolbox_location@@` accordingly).
+
+When capturing test results, the inverse substitution will be performed so that all values present in the `.env` file will be subtitued with their respectives `@@variable_name` in the fixtures. Please takee into account that, while the aforementioned substitution can use all your environment variables, this reverse-substitution will only automatically apply those variables present in the `.env` file.
+
 
 ## Table names and API execution
 


### PR DESCRIPTION
This PR includes downstream changes that were needed in the Snowflake ML extension package, and have been adapted to work with all packages. Some of these are breaking changes that will need to include changes in the other extension packages (I have already made them locally and tested them). The changes are:
- ~~**Change the syntax of env variable interpolation**, from `${...}` to `%%{...}%%`, since the original syntax will prevent us from using string interpolation in JS functions (which is needed in Snowflake quite often)~~ **Edit**: check the comment below regarding the new changes.
- In the same vein, **change the SF body to use `'` instead of `$$`**: single quotes can be programmatically escaped inside a `'` body, but if we use nested `$$` bodies the deployment crashes.
- **Add dry run testing**: for each test configuration, now:
    1. Both dry and full runs are executed,
    2. We check that the column name ~~and types~~ of both runs are equal (**Edit**: check the comment below regarding the new changes),
    3. We finally compare against the expected results (the original tests).
- **Download the test results to a pandas DataFrame**, to keep column names in Snowflake and keep easier typing information (the format in which the results are saved has not been changed).
- **Set a default DB and schema for Snowflake**, taken from the environment variables, which allows us to test functions that create temporal objects.
- **Add reverse variable substitution**: when running `capture`, if the results contain any values contained in the `.env` file, they will be captured to use their key ~~in the `%%{...}%%` syntax~~ **Edit**: check the comment below regarding the new changes

After including these changes, some PRs need to be made to adapt the original packages (to change the variable interpolation syntax) as well as fixing some dry run bugs that were found thanks to the tests.